### PR TITLE
added functionality to close the modal

### DIFF
--- a/components/InputColumnHeader.tsx
+++ b/components/InputColumnHeader.tsx
@@ -24,7 +24,13 @@ export default function InputColumnHeader({
 
   return (
     <div className="flex-20-gap-align-center mb-4" style={{ height: "32px" }}>
-      <Dialog isOpen={isDialogOpen} isCloseButtonShown={true} className="p-8">
+      <Dialog isOpen={isDialogOpen} className="relative p-12">
+        <div className="cursor-pointer" onClick={() => setIsDialogOpen(false)}>
+          <i
+            className="fa-solid fa-xmark absolute right-3 top-3 rounded p-1 px-2 hover:bg-gray-200"
+            style={{ fontSize: "24px" }}
+          ></i>
+        </div>
         <FileUpload
           beforeUploadCallback={(fileContent) => {
             setInput(fileContent);
@@ -32,7 +38,7 @@ export default function InputColumnHeader({
           }}
         />
       </Dialog>
-      <p className="font-semibold text-white text-base tracking-normal">
+      <p className="text-base font-semibold tracking-normal text-white">
         {label}
       </p>
       {showButtons && (


### PR DESCRIPTION
There were multiple ways to do it. One was to add a title prop so the header becomes visible and the header has a button to close the modal by default. I figured adding a title doesn't make a lot of sense from a ux standpoint so i added an icon and an event handler to close it.